### PR TITLE
Fix up black and mypy in `fix-t8n-requests`

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -307,7 +307,7 @@ class Result:
     excess_blob_gas: Optional[U64] = None
     blob_gas_used: Optional[Uint] = None
     requests_hash: Optional[Hash32] = None
-    requests: Optional[Bytes] = None
+    requests: Optional[List[Bytes]] = None
 
     def to_json(self) -> Any:
         """Encode the result to JSON"""

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -356,6 +356,8 @@ class Result:
             data["requestsHash"] = encode_to_hex(self.requests_hash)
             # T8N doesn't consider the request type byte to be part of the
             # request
-            data["requests"] = [encode_to_hex(req[1:]) for req in self.requests]
+            data["requests"] = [
+                encode_to_hex(req[1:]) for req in self.requests
+            ]
 
         return data


### PR DESCRIPTION
### What was wrong?

Fixes `tox -e static`, which is failing in #1040.

Couldn't suggest the `mypy` fix in a review, so adding here.

#### Cute Animal Picture

![Cute hedgehog](https://github.com/user-attachments/assets/089bd96e-0a92-43e8-9abf-0da448bf6320)
