### PR TITLE
EIP-7742: Use `parent.target_blob_gas_per_block` in excess blob gas calculation

### DIFF
--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -199,7 +199,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         Block to apply to `chain`.
     """
     parent_header = chain.blocks[-1].header
-    excess_blob_gas = calculate_excess_blob_gas(block.header, parent_header)
+    excess_blob_gas = calculate_excess_blob_gas(parent_header)
     if block.header.excess_blob_gas != excess_blob_gas:
         raise InvalidBlock
 

--- a/src/ethereum/prague/vm/gas.py
+++ b/src/ethereum/prague/vm/gas.py
@@ -267,7 +267,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
     return GAS_INIT_CODE_WORD_COST * ceil32(init_code_length) // 32
 
 
-def calculate_excess_blob_gas(header: Header, parent_header: Header) -> U64:
+def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
     Calculated the excess blob gas for the current block based
     on the gas used in the parent block and the gas target set
@@ -275,8 +275,6 @@ def calculate_excess_blob_gas(header: Header, parent_header: Header) -> U64:
 
     Parameters
     ----------
-    header :
-        The header of the current block.
     parent_header :
         The parent block of the current block.
 
@@ -288,7 +286,7 @@ def calculate_excess_blob_gas(header: Header, parent_header: Header) -> U64:
     parent_blob_gas = (
         parent_header.excess_blob_gas + parent_header.blob_gas_used
     )
-    blob_gas = GAS_PER_BLOB * header.target_blobs_per_block
+    blob_gas = GAS_PER_BLOB * parent_header.target_blobs_per_block
     if parent_blob_gas < blob_gas:
         return U64(0)
     else:

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -52,6 +52,7 @@ class Env:
     excess_blob_gas: Optional[U64]
     requests: Any
     target_blobs_per_block: Optional[U64]
+    parent_target_blobs_per_block: Optional[U64]
 
     def __init__(self, t8n: "T8N", stdin: Optional[Dict] = None):
         if t8n.options.input_env == "stdin":
@@ -91,7 +92,7 @@ class Env:
         self.parent_blob_gas_used = U64(0)
         self.parent_excess_blob_gas = U64(0)
         self.excess_blob_gas = None
-        self.target_blobs_per_block = None
+        self.parent_target_blobs_per_block = None
 
         if not t8n.fork.is_after_fork("ethereum.cancun"):
             return
@@ -116,19 +117,23 @@ class Env:
             self.parent_excess_blob_gas + self.parent_blob_gas_used
         )
 
-        if "currentTargetBlobsPerBlock" in data:
-            self.target_blobs_per_block = parse_hex_or_int(
-                data["currentTargetBlobsPerBlock"], U64
+        if "parentTargetBlobsPerBlock" in data:
+            self.parent_target_blobs_per_block = parse_hex_or_int(
+                data["parentTargetBlobsPerBlock"], U64
             )
-            target_blob_gas_per_block = (
-                self.target_blobs_per_block * t8n.fork.GAS_PER_BLOB
+            parent_target_blob_gas_per_block = (
+                self.parent_target_blobs_per_block * t8n.fork.GAS_PER_BLOB
             )
         else:
-            target_blob_gas_per_block = t8n.fork.TARGET_BLOB_GAS_PER_BLOCK
+            parent_target_blob_gas_per_block = (
+                t8n.fork.TARGET_BLOB_GAS_PER_BLOCK
+            )
 
         self.excess_blob_gas = U64(0)
-        if excess_blob_gas >= target_blob_gas_per_block:
-            self.excess_blob_gas = excess_blob_gas - target_blob_gas_per_block
+        if excess_blob_gas >= parent_target_blob_gas_per_block:
+            self.excess_blob_gas = (
+                excess_blob_gas - parent_target_blob_gas_per_block
+            )
 
         if "currentTargetBlobsPerBlock" in data:
             self.target_blobs_per_block = parse_hex_or_int(


### PR DESCRIPTION
### What was wrong?

Addresses changes in https://github.com/ethereum/EIPs/pull/9122 to EIP-7742.

### How was it fixed?

Modified the formula to use the target blob count of the parent header instead of the one in the current block.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://vetmed.illinois.edu/wp-content/uploads/2021/04/pc-keller-hedgehog.jpg)
