### PR TITLE
Add bytecode and ancestors to state tracker

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -79,6 +79,8 @@ from .state_tracking import (
     increment_nonce,
     modify_state,
     set_account_balance,
+    track_ancestor_access,
+    track_bytecode_access,
     write_block_state_changes,
 )
 from .transactions import (
@@ -752,6 +754,7 @@ def process_checked_system_transaction(
     system_contract_code = get_account(
         block_env.state_tracking, target_address
     ).code
+    track_bytecode_access(block_env.state_tracking, system_contract_code)
 
     if len(system_contract_code) == 0:
         raise InvalidBlock(
@@ -802,6 +805,7 @@ def process_unchecked_system_transaction(
     system_contract_code = get_account(
         block_env.state_tracking, target_address
     ).code
+    track_bytecode_access(block_env.state_tracking, system_contract_code)
     return process_system_transaction(
         block_env,
         target_address,
@@ -856,6 +860,11 @@ def apply_body(
         block_env=block_env,
         target_address=HISTORY_STORAGE_ADDRESS,
         data=block_env.block_hashes[-1],  # The parent hash
+    )
+    # Track parent block access for witness generation
+    track_ancestor_access(
+        block_env.state_tracking,
+        U64(block_env.number - Uint(1)),
     )
 
     for i, tx in enumerate(map(decode_transaction, transactions)):

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -252,6 +252,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
             storage_reads=set(),
             account_writes={},
             storage_writes={},
+            bytecode_accesses=set(),
+            ancestor_accesses=set(),
         ),
         block_gas_limit=block.header.gas_limit,
         block_hashes=get_last_256_block_hashes(chain),
@@ -671,6 +673,8 @@ def process_system_transaction(
             account_writes={},
             storage_writes={},
             created_accounts=set(),
+            bytecode_accesses=set(),
+            ancestor_accesses=set(),
         ),
     )
 
@@ -704,6 +708,8 @@ def process_system_transaction(
             account_writes={},
             storage_writes={},
             created_accounts=set(),
+            bytecode_accesses=set(),
+            ancestor_accesses=set(),
         ),
         transient_storage={},
     )
@@ -956,6 +962,8 @@ def process_transaction(
         account_writes={},
         storage_writes={},
         created_accounts=set(),
+        bytecode_accesses=set(),
+        ancestor_accesses=set(),
     )
 
     # EIP-7928: Create a transaction-level StateChanges frame

--- a/src/ethereum/forks/amsterdam/state_tracking.py
+++ b/src/ethereum/forks/amsterdam/state_tracking.py
@@ -35,10 +35,8 @@ class BlockStateTracking:
         Address, Dict[Bytes32, List[Tuple[BlockAccessIndex, U256]]]
     ]
 
-    # Witness: all bytecodes accessed during block execution
     bytecode_accesses: Set[Bytes]
 
-    # Witness: all ancestor block numbers accessed during block execution
     ancestor_accesses: Set[U64]
 
 
@@ -172,8 +170,6 @@ def incorporate_tx_state_into_parent(tx_state: TxStateTracking) -> None:
     for address, items in tx_state.storage_writes.items():
         for key, value in items.items():
             set_storage(parent, address, key, value)
-
-    # Merge witness tracking
     parent.bytecode_accesses |= tx_state.bytecode_accesses
     parent.ancestor_accesses |= tx_state.ancestor_accesses
 

--- a/src/ethereum/forks/amsterdam/state_tracking.py
+++ b/src/ethereum/forks/amsterdam/state_tracking.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U64, U256, Uint
 
 from . import state as state_
 from .fork_types import EMPTY_ACCOUNT, Account, Address
@@ -35,6 +35,12 @@ class BlockStateTracking:
         Address, Dict[Bytes32, List[Tuple[BlockAccessIndex, U256]]]
     ]
 
+    # Witness: all bytecodes accessed during block execution
+    bytecode_accesses: Set[Bytes]
+
+    # Witness: all ancestor block numbers accessed during block execution
+    ancestor_accesses: Set[U64]
+
 
 @dataclass
 class TxStateTracking:
@@ -51,6 +57,10 @@ class TxStateTracking:
     storage_writes: Dict[Address, Dict[Bytes32, U256]]
 
     created_accounts: Set[Address]
+
+    bytecode_accesses: Set[Bytes]
+
+    ancestor_accesses: Set[U64]
 
 
 # get_account_optional
@@ -163,6 +173,10 @@ def incorporate_tx_state_into_parent(tx_state: TxStateTracking) -> None:
         for key, value in items.items():
             set_storage(parent, address, key, value)
 
+    # Merge witness tracking
+    parent.bytecode_accesses |= tx_state.bytecode_accesses
+    parent.ancestor_accesses |= tx_state.ancestor_accesses
+
 
 def write_block_state_changes(block_state: BlockStateTracking) -> None:
     """
@@ -193,6 +207,8 @@ def copy_tx_state_tracking(tx_state: TxStateTracking) -> TxStateTracking:
         account_writes=tx_state.account_writes.copy(),
         storage_writes=new_storage_writes,
         created_accounts=tx_state.created_accounts.copy(),
+        bytecode_accesses=tx_state.bytecode_accesses.copy(),
+        ancestor_accesses=tx_state.ancestor_accesses.copy(),
     )
 
 
@@ -518,3 +534,43 @@ def get_storage_original(
         return U256(0)
 
     return get_storage(state.parent, address, key)
+
+
+def track_bytecode_access(
+    state: TxStateTracking | BlockStateTracking,
+    code: Bytes,
+) -> None:
+    """
+    Record that bytecode was accessed during execution.
+
+    Parameters
+    ----------
+    state :
+        The state tracking object.
+    code :
+        The bytecode that was accessed.
+
+    """
+    state.bytecode_accesses.add(code)
+
+
+def track_ancestor_access(
+    state: TxStateTracking | BlockStateTracking,
+    block_number: U64,
+) -> None:
+    """
+    Record that an ancestor block was accessed.
+
+    Called by:
+    - BLOCKHASH opcode (when returning valid hash)
+    - System contracts reading parent headers (EIP-2935)
+
+    Parameters
+    ----------
+    state :
+        The state tracking object.
+    block_number :
+        The block number that was accessed.
+
+    """
+    state.ancestor_accesses.add(block_number)

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -23,6 +23,7 @@ from ..state_tracking import (
     get_account,
     increment_nonce,
     set_authority_code,
+    track_bytecode_access,
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import GAS_COLD_ACCOUNT_ACCESS, GAS_WARM_ACCESS
@@ -145,6 +146,7 @@ def calculate_delegation_cost(
     """
     state = evm.state_tracking
     code = get_account(state, address).code
+    track_bytecode_access(evm.state_tracking, code)
     track_address(evm.state_changes, address)
 
     if not is_valid_delegation(code):

--- a/src/ethereum/forks/amsterdam/vm/instructions/block.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/block.py
@@ -11,8 +11,9 @@ Introduction
 Implementations of the EVM block instructions.
 """
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U64, U256, Uint
 
+from ...state_tracking import track_ancestor_access
 from .. import Evm
 from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
@@ -57,6 +58,7 @@ def block_hash(evm: Evm) -> None:
         current_block_hash = evm.message.block_env.block_hashes[
             -(current_block_number - block_number)
         ]
+        track_ancestor_access(evm.state_tracking, U64(block_number))
 
     push(evm.stack, U256.from_be_bytes(current_block_hash))
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 # track_address_access removed - now using state_changes.track_address()
 from ...fork_types import EMPTY_ACCOUNT
 from ...state_tracker import track_address
-from ...state_tracking import get_account
+from ...state_tracking import get_account, track_bytecode_access
 from ...utils.address import to_address_masked
 from ...vm.memory import buffer_read, memory_write
 from .. import Evm
@@ -356,6 +356,7 @@ def extcodesize(evm: Evm) -> None:
 
     # OPERATION
     code = get_account(evm.state_tracking, address).code
+    track_bytecode_access(evm.state_tracking, code)
     track_address(evm.state_changes, address)
 
     codesize = U256(len(code))
@@ -402,6 +403,7 @@ def extcodecopy(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.state_tracking, address).code
+    track_bytecode_access(evm.state_tracking, code)
     track_address(evm.state_changes, address)
 
     value = buffer_read(code, code_start_index, size)

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -32,6 +32,7 @@ from ...state_tracking import (
     is_account_alive,
     move_ether,
     set_account_balance,
+    track_bytecode_access,
 )
 from ...utils.address import (
     compute_contract_address,
@@ -458,6 +459,7 @@ def call(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code = get_account(state, code_address).code
+    track_bytecode_access(evm.state_tracking, code)
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -561,6 +563,7 @@ def callcode(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code = get_account(state, code_address).code
+    track_bytecode_access(evm.state_tracking, code)
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -757,6 +760,7 @@ def delegatecall(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code = get_account(state, code_address).code
+    track_bytecode_access(evm.state_tracking, code)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),
@@ -847,6 +851,7 @@ def staticcall(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code = get_account(state, code_address).code
+    track_bytecode_access(evm.state_tracking, code)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -50,6 +50,7 @@ from ..state_tracking import (
     mark_account_created,
     move_ether,
     set_code,
+    track_bytecode_access,
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
@@ -141,6 +142,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
             message.disable_precompiles = True
             message.accessed_addresses.add(delegated_address)
             message.code = get_account(state_tracking, delegated_address).code
+            track_bytecode_access(message.state_tracking, message.code)
             message.code_address = delegated_address
             track_address(message.block_env.state_changes, delegated_address)
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -321,6 +321,8 @@ class T8N(Load):
             storage_reads=set(),
             account_writes={},
             storage_writes={},
+            bytecode_accesses=set(),
+            ancestor_accesses=set(),
         )
 
         return block_environment(**kw_arguments)
@@ -396,6 +398,11 @@ class T8N(Load):
                 block_env=block_env,
                 target_address=self.fork.HISTORY_STORAGE_ADDRESS,
                 data=block_env.block_hashes[-1],  # The parent hash
+            )
+            # Track parent block access for witness generation
+            self.fork._module("state_tracking").track_ancestor_access(
+                block_env.state_tracking,
+                U64(block_env.number - Uint(1)),
             )
 
         if self.fork.has_beacon_roots_address:


### PR DESCRIPTION
## Summary

This PR extends the state tracking infrastructure to record bytecode and ancestor block accesses during execution, which is necessary for witness generation.

### Changes

**State tracking infrastructure**:
- Add `bytecode_accesses: Set[Bytes]` to track all bytecodes accessed during block execution
- Add `ancestor_accesses: Set[U64]` to track all ancestor block numbers accessed
- Add `track_bytecode_access()` and `track_ancestor_access()` helper functions
- Merge witness tracking when incorporating transaction state into parent

**Bytecode tracking** - records code accessed via:
- CALL, CALLCODE, DELEGATECALL, STATICCALL opcodes
- EXTCODESIZE, EXTCODECOPY opcodes
- EIP-7702 delegation resolution
- System contract execution

**Ancestor tracking** - records blocks accessed via:
- BLOCKHASH opcode
- EIP-2935 history storage system call
